### PR TITLE
Competitor Profile fix

### DIFF
--- a/htdocs/profile/stats-detail/index.php
+++ b/htdocs/profile/stats-detail/index.php
@@ -31,6 +31,11 @@
 			$uuid = $_SESSION['uuid'];
 		}
 		if (isset($_POST["season_id"])){
+			if ($_POST["season_id"] == "CURRENT"){
+				unset($_POST["season_id"]); //Unset this post argument when selecting the 'back to current season' option
+			}
+		}
+		if (isset($_POST["season_id"])){
 			$season_id = $_POST["season_id"];
 			$seasonRecords = svc_getPlayerRankInfoBySeason($uuid, $season_id);
 		} else {
@@ -146,10 +151,11 @@
 			<form id="seasonSelect" action=<?=$_SERVER['PHP_SELF'];?> method="post">
 				<select name="season_id" onchange="document.getElementById('seasonSelect').submit()" style="display: block; margin: 0 auto">
 					<?php if (isset($_POST["season_id"])) : ?>
-						<?php svc_echoSeasonList(true, $season_id); ?>
+						<option value="CURRENT">Back to Current Season</option>
+						<?php svc_echoSeasonList(false, $season_id); ?>
 					<?php else : ?>
 						<option value="" selected>View Other Seasons...</option>
-						<?php svc_echoSeasonList(true); ?>
+						<?php svc_echoSeasonList(false); ?>
 					<?php endif; ?>
 				</select>
 			</form>
@@ -165,7 +171,11 @@
 				<?php else : ?>
 				<tr>
 					<td>Current Rating</td>
+					<?php if($profile['rank_placements']==0) : ?>
 					<td><?=$profile['rank_current'];?> <img style="width: 24px; height: 24px; vertical-align: middle" src=<?=svc_getEmblemByRank($profile['rank_current'], $profile['rank_season_high']);?> /></td>
+					<?php else : ?>
+					<td>Not Placed</td>
+					<?php endif; ?>
 				</tr>
 				<?php endif; ?>
 				<tr>
@@ -181,7 +191,11 @@
 					<?php if(isset($_POST["season_id"])) : ?>
 					<td><?=$seasonRecords['rec_rank_initial'];?> <img style="width: 24px; height: 24px; vertical-align: middle" src=<?=svc_getEmblemByRank($seasonRecords['rec_rank_initial'], $seasonRecords['rec_rank_initial']);?> /></td>
 					<?php else : ?>
-					<td><?=$profile['rank_initial'];?> <img style="width: 24px; height: 24px; vertical-align: middle" src=<?=svc_getEmblemByRank($profile['rank_initial'], $profile['rank_initial']);?> /></td>
+						<?php if($profile['rank_placements']==0) : ?>
+							<td><?=$profile['rank_initial'];?> <img style="width: 24px; height: 24px; vertical-align: middle" src=<?=svc_getEmblemByRank($profile['rank_initial'], $profile['rank_initial']);?> /></td>
+						<?php else : ?>
+							<td>Not Placed</td>
+						<?php endif; ?>
 					<?php endif; ?>
 				</tr>
 				<tr>
@@ -189,7 +203,11 @@
 					<?php if(isset($_POST["season_id"])) : ?>
 					<?php drawRankDelta($seasonRecords['rec_rank_initial'], $seasonRecords['rec_rank_final']); ?>
 					<?php else : ?>
-					<?php drawRankDelta($profile['rank_initial'], $profile['rank_current']); ?>
+						<?php if($profile['rank_placements']==0) {
+							drawRankDelta($profile['rank_initial'], $profile['rank_current']);
+						} else {
+							echo "<td>N/A</td>";
+						} ?>
 					<?php endif; ?>
 				</tr>
 				<tr><td colspan="2" class="competitor-table-spacer">&nbsp;</td></tr>

--- a/htdocs/service/svc_records_lookup.php
+++ b/htdocs/service/svc_records_lookup.php
@@ -134,16 +134,19 @@ function svc_getRecordsByGame($uuid, $game_id){
 		$rs3 = mysqli_query($db, $query3);
 		$curr = mysqli_fetch_assoc($rs3);
 		if (!$curr){
-
+			writeLog(ERROR, "Failed to get current season data in svc_getRecordsByGame");
+			writeLog(ERROR, mysqli_error($db));
 		}
 
-		$assoc["seasons"]++;
-		$total_final += $curr["rank_current"];
-		$total_init += $curr["rank_initial"];
-		$assoc["wins"] += $curr["rank_season_wins"];
-		$assoc["losses"] += $curr["rank_season_losses"];
-		if ($curr["rank_season_high"] > $assoc["highest"]){
-			$assoc["highest"] = $curr["rank_season_high"];
+		if ($curr["rank_placements"] == 0){ //Do not factor in the current season if the member has not completed placement yet
+			$assoc["seasons"]++;
+			$total_final += $curr["rank_current"];
+			$total_init += $curr["rank_initial"];
+			$assoc["wins"] += $curr["rank_season_wins"];
+			$assoc["losses"] += $curr["rank_season_losses"];
+			if ($curr["rank_season_high"] > $assoc["highest"]){
+				$assoc["highest"] = $curr["rank_season_high"];
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #148. Current-season ranks now display "Not Placed" when the logged-in user has not completed placement in the current season. Also adjusted the records-by-game section to not factor in the current season unless placement has been completed.

Another minor fix: "Back to Current Season" option in the dropdown for records-by-season. Previously this did not work as it would look for current data in the records table.